### PR TITLE
Fix the book duplication issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ KoboCloud keeps a log of each session in the .kobo/kobocloud/get.log file. If so
 
 ## Known issues
 * No subdirectories are supported
-* Some versions of Kobo make the same book appear twice in the library. This is because it scans the internal directory where the files are saved as well as the "official" folders. To solve this problem find the `Kobo eReader.conf`file inside your `.kobo` folder and add the the following line in the `[FeatureSettings]` section:
+* Some versions of Kobo make the same book appear twice in the library. This is because it scans the internal directory where the files are saved as well as the "official" folders. To solve this problem find the `Kobo eReader.conf` file inside your `.kobo` folder and make sure the following line (which prevents the syncing of dotfiles and dotfolders) is set in the `[FeatureSettings]` section:
 ```
-  ExcludeSyncFolders=Library
+  ExcludeSyncFolders=\\.(?!kobo|adobe).*?
 ```
 
 

--- a/src/usr/local/kobocloud/config_kobo.sh
+++ b/src/usr/local/kobocloud/config_kobo.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-Logs=/mnt/onboard/.kobo/kobocloud
-Lib=/mnt/onboard/.kobo/kobocloud/Library
+Logs=/mnt/onboard/.adds/kobocloud
+Lib=/mnt/onboard/.adds/kobocloud/Library
 SD=/mnt/sd/kobocloud
-UserConfig=/mnt/onboard/.kobo/kobocloud/kobocloudrc
+UserConfig=/mnt/onboard/.adds/kobocloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL="`dirname $0`/curl --cacert \"`dirname $0`/ca-bundle.crt\" "


### PR DESCRIPTION
These changes fix the books duplication issue which users are still experiencing (see https://www.mobileread.com/forums/showthread.php?t=316894 and issue #13), by preventing KoboCloud's own library from getting synced by Nickel OS (in addition to /mnt/sd/kobocloud where books are pushed to).

The installation folder is simply changed from '.kobo' to '.adds'. Sub-folders of '.kobo' do get synced by default (which we don't want) plus it is generally not recommended to write in it as it'll get wiped by a signout or a database corruption. '.adds' is a standard location used by other apps such as KOReader. Dotfolders will need to be excluded from library scan with the regular line entry in Kobo eReader.conf` (see readme).