### PR TITLE
Add error handling and enhance logging

### DIFF
--- a/src/usr/local/kobocloud/config_kobo.sh
+++ b/src/usr/local/kobocloud/config_kobo.sh
@@ -5,4 +5,4 @@ SD=/mnt/sd/kobocloud
 UserConfig=/mnt/onboard/.add/kobocloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL="`dirname $0`/curl --cacert \"`dirname $0`/ca-bundle.crt\" "
-UserAgent="Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0"
+UserAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"

--- a/src/usr/local/kobocloud/config_kobo.sh
+++ b/src/usr/local/kobocloud/config_kobo.sh
@@ -5,3 +5,4 @@ SD=/mnt/sd/kobocloud
 UserConfig=/mnt/onboard/.add/kobocloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL="`dirname $0`/curl --cacert \"`dirname $0`/ca-bundle.crt\" "
+UserAgent="Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0"

--- a/src/usr/local/kobocloud/config_kobo.sh
+++ b/src/usr/local/kobocloud/config_kobo.sh
@@ -5,6 +5,3 @@ SD=/mnt/sd/kobocloud
 UserConfig=/mnt/onboard/.add/kobocloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL="`dirname $0`/curl --cacert \"`dirname $0`/ca-bundle.crt\" "
-UserAgent=""
-CurlExtra=""
-GdriveCurlExtra=""

--- a/src/usr/local/kobocloud/config_kobo.sh
+++ b/src/usr/local/kobocloud/config_kobo.sh
@@ -6,3 +6,5 @@ UserConfig=/mnt/onboard/.add/kobocloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL="`dirname $0`/curl --cacert \"`dirname $0`/ca-bundle.crt\" "
 UserAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+CurlExtra=""
+GdriveCurlExtra="-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' -H 'Accept-Language: en-US;q=0.5,en;q=0.3' --compressed -H 'Connection: keep-alive'"

--- a/src/usr/local/kobocloud/config_kobo.sh
+++ b/src/usr/local/kobocloud/config_kobo.sh
@@ -5,6 +5,6 @@ SD=/mnt/sd/kobocloud
 UserConfig=/mnt/onboard/.add/kobocloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL="`dirname $0`/curl --cacert \"`dirname $0`/ca-bundle.crt\" "
-UserAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+UserAgent=""
 CurlExtra=""
-GdriveCurlExtra="-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' -H 'Accept-Language: en-US;q=0.5,en;q=0.3' --compressed -H 'Connection: keep-alive'"
+GdriveCurlExtra=""

--- a/src/usr/local/kobocloud/config_pc.sh
+++ b/src/usr/local/kobocloud/config_pc.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
-Logs=/home/francesco/src/KoboCloud
-Lib=/home/francesco/src/KoboCloud/Library
-SD=/home/francesco/src/KoboCloud
-UserConfig=/home/francesco/src/KoboCloud/kobocloudrc
+Logs=/tmp/KoboCloud
+Lib=/tmp/KoboCloud/Library
+SD=/tmp/KoboCloud
+UserConfig=/tmp/KoboCloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL=/usr/bin/curl
+UserAgent="Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0"

--- a/src/usr/local/kobocloud/config_pc.sh
+++ b/src/usr/local/kobocloud/config_pc.sh
@@ -5,4 +5,4 @@ SD=/tmp/KoboCloud
 UserConfig=/tmp/KoboCloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL=/usr/bin/curl
-UserAgent="Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:59.0) Gecko/20100101 Firefox/59.0"
+UserAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"

--- a/src/usr/local/kobocloud/config_pc.sh
+++ b/src/usr/local/kobocloud/config_pc.sh
@@ -5,6 +5,6 @@ SD=/tmp/KoboCloud
 UserConfig=/tmp/KoboCloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL=/usr/bin/curl
-UserAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+UserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36"
 CurlExtra=""
 GdriveCurlExtra="-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' -H 'Accept-Language: en-US;q=0.5,en;q=0.3' --compressed -H 'Connection: keep-alive'"

--- a/src/usr/local/kobocloud/config_pc.sh
+++ b/src/usr/local/kobocloud/config_pc.sh
@@ -5,6 +5,3 @@ SD=/tmp/KoboCloud
 UserConfig=/tmp/KoboCloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL=/usr/bin/curl
-UserAgent="Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36"
-CurlExtra=""
-GdriveCurlExtra="-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' -H 'Accept-Language: en-US;q=0.5,en;q=0.3' --compressed -H 'Connection: keep-alive'"

--- a/src/usr/local/kobocloud/config_pc.sh
+++ b/src/usr/local/kobocloud/config_pc.sh
@@ -6,3 +6,5 @@ UserConfig=/tmp/KoboCloud/kobocloudrc
 Dt="date +%Y-%m-%d_%H:%M:%S"
 CURL=/usr/bin/curl
 UserAgent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
+CurlExtra=""
+GdriveCurlExtra="-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8' -H 'Accept-Language: en-US;q=0.5,en;q=0.3' --compressed -H 'Connection: keep-alive'"

--- a/src/usr/local/kobocloud/getDropboxFiles.sh
+++ b/src/usr/local/kobocloud/getDropboxFiles.sh
@@ -26,4 +26,8 @@ do
   #echo $outFileName
   localFile="$outDir/$outFileName"
   `dirname $0`/getRemoteFile.sh "$linkLine" "$localFile"
+  if [ $? -ne 0 ] ; then
+      echo "Having problems contacting Dropbox. Try again in a couple of minutes."
+      exit
+  fi
 done

--- a/src/usr/local/kobocloud/getGDriveFiles.sh
+++ b/src/usr/local/kobocloud/getGDriveFiles.sh
@@ -26,7 +26,8 @@ do
     linkLine="https://drive.google.com/uc?id=$fileCode&export=download"
     outFileName=`echo $fileName | tr ' ' '_'`
     localFile="$outDir/$outFileName"
-    `dirname $0`/getRemoteFile.sh "$linkLine" "$localFile"
+
+    `dirname $0`/getRemoteFile.sh "$linkLine" "$localFile" "-" "$GdriveCurlExtra"
     if [ $? ] ; then
         echo "Having problems contacting Google Drive. Try again in a couple of minutes."
         exit

--- a/src/usr/local/kobocloud/getGDriveFiles.sh
+++ b/src/usr/local/kobocloud/getGDriveFiles.sh
@@ -18,13 +18,17 @@ $CURL -k -L --silent "$baseURL" |
 grep -Eo "\\\x5b\\\x22[^\\\]*\\\x22,\\\x5b\\\x22$gDirCode\\\x22\\\x5d\\\n,\\\x22[^\\\]*" | # find links
 while read fileInfo
 do
-    echo $fileInfo
+    echo "File info: $fileInfo"
     fileCode=`echo $fileInfo | sed -n 's/x5bx22\([^\\\]*\)x22,.*/\1/p'` # extract the code for file download (this is how a file is identified in GDrive)
     fileName=`echo $fileInfo | sed -n 's/.*x22\(.*\)$/\1/p'` # extract the file name
-    echo $fileCode
-    echo $fileName
+    echo "File code: $fileCode"
+    echo "File name: $fileName"
     linkLine="https://drive.google.com/uc?id=$fileCode&export=download"
     outFileName=`echo $fileName | tr ' ' '_'`
     localFile="$outDir/$outFileName"
     `dirname $0`/getRemoteFile.sh "$linkLine" "$localFile"
+    if [ "$?" = "2" ]; then
+        echo "Google detected automated requests. Try again in a couple of minutes."
+        exit
+    fi
 done

--- a/src/usr/local/kobocloud/getGDriveFiles.sh
+++ b/src/usr/local/kobocloud/getGDriveFiles.sh
@@ -28,7 +28,7 @@ do
     localFile="$outDir/$outFileName"
 
     `dirname $0`/getRemoteFile.sh "$linkLine" "$localFile" "-" "$GdriveCurlExtra"
-    if [ $? ] ; then
+    if [ $? -ne 0 ] ; then
         echo "Having problems contacting Google Drive. Try again in a couple of minutes."
         exit
     fi

--- a/src/usr/local/kobocloud/getGDriveFiles.sh
+++ b/src/usr/local/kobocloud/getGDriveFiles.sh
@@ -27,8 +27,8 @@ do
     outFileName=`echo $fileName | tr ' ' '_'`
     localFile="$outDir/$outFileName"
     `dirname $0`/getRemoteFile.sh "$linkLine" "$localFile"
-    if [ "$?" = "2" ]; then
-        echo "Google detected automated requests. Try again in a couple of minutes."
+    if [ $? ] ; then
+        echo "Having problems contacting Google Drive. Try again in a couple of minutes."
         exit
     fi
 done

--- a/src/usr/local/kobocloud/getGDriveFiles.sh
+++ b/src/usr/local/kobocloud/getGDriveFiles.sh
@@ -13,7 +13,6 @@ echo "Getting $baseURL"
 gDirCode=`echo $baseURL | sed 's@.*/\([^/\?]*\).*@\1@'`
 
 echo $gDirCode
-
 $CURL -k -L --silent "$baseURL" |
 grep -Eo "\\\x5b\\\x22[^\\\]*\\\x22,\\\x5b\\\x22$gDirCode\\\x22\\\x5d\\\n,\\\x22[^\\\]*" | # find links
 while read fileInfo
@@ -27,7 +26,7 @@ do
     outFileName=`echo $fileName | tr ' ' '_'`
     localFile="$outDir/$outFileName"
 
-    `dirname $0`/getRemoteFile.sh "$linkLine" "$localFile" "-" "$GdriveCurlExtra"
+    `dirname $0`/getRemoteFile.sh "$linkLine" "$localFile"
     if [ $? -ne 0 ] ; then
         echo "Having problems contacting Google Drive. Try again in a couple of minutes."
         exit

--- a/src/usr/local/kobocloud/getOwncloudFiles.sh
+++ b/src/usr/local/kobocloud/getOwncloudFiles.sh
@@ -25,4 +25,8 @@ do
   localFile="$outDir/$outFileName"
   # get remote file
   `dirname $0`/getRemoteFile.sh "$linkLine" "$localFile" $shareID
+  if [ $? -ne 0 ] ; then
+      echo "Having problems contacting Owncloud. Try again in a couple of minutes."
+      exit
+  fi
 done

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -26,7 +26,7 @@ $curlHead > $remoteInfo
 echo "  Status: $?"
 
 remoteSize=`cat $remoteInfo | tr A-Z a-z | sed -n 's/^content-length\: \([1-9]*\).*/\1/p'`
-statusCode=`cat $remoteInfo | grep 'HTTP/2 ' | tail -n 1 | cut -d' ' -f2`
+statusCode=`cat $remoteInfo | grep 'HTTP/' | tail -n 1 | cut -d' ' -f2`
 echo "Remote file information:"
 echo "  Remote size: $remoteSize"
 echo "  Status code: $statusCode"

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -32,37 +32,40 @@ echo "  Command: '$curlHead'"
 $curlHead > $remoteInfo
 echo "  Status: $?"
 
-remoteSize=`cat $remoteInfo | tr A-Z a-z | sed -n 's/^content-length\: \([1-9]*\).*/\1/p'`
+remoteSize=`cat $remoteInfo | tr A-Z a-z | grep 'content-length:' | tail -n 1 | cut -d' ' -f2`
 statusCode=`cat $remoteInfo | grep 'HTTP/' | tail -n 1 | cut -d' ' -f2`
 echo "Remote file information:"
 echo "  Remote size: $remoteSize"
 echo "  Status code: $statusCode"
 rm "$remoteInfo"
 
-if echo "$statusCode" | grep -q "4.*"; then
+if echo "$statusCode" | grep -q "403"; then
     echo "Error: Forbidden"
     exit 2
 fi
-if echo "$statusCode" | grep -q "5.*"; then
+if echo "$statusCode" | grep -q "50.*"; then
     echo "Error: Server error"
     exit 3
 fi
 
-if [ -f $localFile ]; then
-  localSize=`stat -c%s "$localFile"`
+if [ -f "$localFile" ]; then
+    localSize=`stat -c%s "\"$localFile\""`
 else
-  localSize=0
+    localSize=0
 fi
 if [ "$remoteSize" = "" ]; then
-  remoteSize=1
+    remoteSize=1
 fi
-if [ $localSize -ge $remoteSize ]; then
-  echo "File exists: skipping"
+if [ "$localSize" -ge $remoteSize ]; then
+    echo "File exists: skipping"
 else
-  $curlCommand -k --silent -C - -L -o "$localFile" "$linkLine" # try resuming
-  if [ $? -ne 0 ]; then
-    echo "Error resuming: redownload file"
-    $curlCommand -k --silent -L -o "$localFile" "$linkLine" # restart download
-  fi
+    $curlCommand -k --silent -C - -L -o "\"$localFile\"" "$linkLine" # try resuming
+    status=$?
+    echo "Status: $?"
+    if [ $status -ne 0 ]; then
+        echo "Error resuming: redownload file ($status)"
+        $curlCommand -k --silent -L -o "\"$localFile\"" "$linkLine" # restart download
+        echo "Status: $?"
+    fi
 fi
 echo "getRemoteFile ended"

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -3,8 +3,7 @@
 linkLine="$1"
 localFile="$2"
 user="$3"
-extra="$4"
-remoteInfo="/tmp/.kobocloud-remote-file-info.txt"
+outputFileTmp="/tmp/kobo-remote-file-tmp.log"
 
 #load config
 . `dirname $0`/config.sh
@@ -15,58 +14,29 @@ if [ ! -z "$user" ] && [ "$user" != "-" ]; then
     curlCommand="$curlCommand -u $user: "
 fi
 
-if [ ! -z "$UserAgent" ]; then
-    echo "Using custom userAgent: $UserAgent"
-    curlCommand="$curlCommand -A '$UserAgent' "
-fi
+echo "Download: "$curlCommand -k --silent -C - -L -o "$localFile" "$linkLine" -v
 
-curlCommand="$curlCommand $CurlExtra "
-if [ ! -z "$extra" ]; then
-    echo "Adding extra curl arguments: $extra"
-    curlCommand="$curlCommand $extra"
-fi
+$curlCommand -k --silent -C - -L -o "$localFile" "$linkLine" -v 2>$outputFileTmp
+status=$?
+echo "Status: $status"
+echo "Output: "
+cat $outputFileTmp
 
-curlHead="$curlCommand -k -L --silent --head $linkLine"
-echo "Getting remote file information:"
-echo "  Command: '$curlHead'"
-$curlHead > $remoteInfo
-echo "  Status: $?"
+statusCode=`cat $outputFileTmp | grep 'HTTP/' | tail -n 1 | cut -d' ' -f3`
+rm $outputFileTmp
 
-remoteSize=`cat $remoteInfo | tr A-Z a-z | grep 'content-length:' | tail -n 1 | cut -d' ' -f2`
-statusCode=`cat $remoteInfo | grep 'HTTP/' | tail -n 1 | cut -d' ' -f2`
 echo "Remote file information:"
-echo "  Remote size: $remoteSize"
 echo "  Status code: $statusCode"
-rm "$remoteInfo"
 
 if echo "$statusCode" | grep -q "403"; then
     echo "Error: Forbidden"
+    rm $localFile
     exit 2
 fi
 if echo "$statusCode" | grep -q "50.*"; then
     echo "Error: Server error"
+    rm $localFile
     exit 3
 fi
 
-if [ -f "$localFile" ]; then
-    localSize=`stat -c%s "$localFile"`
-else
-    localSize=0
-fi
-if [ "$remoteSize" = "" ]; then
-    remoteSize=1
-fi
-if [ "$localSize" -ge $remoteSize ]; then
-    echo "File exists: skipping"
-else
-    echo "Download: "$curlCommand -k --silent -C - -L -o "$localFile" "$linkLine" # try resuming
-    $curlCommand -k --silent -C - -L -o "$localFile" "$linkLine" # try resuming
-    status=$?
-    echo "Status: $?"
-    if [ $status -ne 0 ]; then
-        echo "Error resuming: redownload file ($status)"
-        $curlCommand -k --silent -L -o "$localFile" "$linkLine" # restart download
-        echo "Status: $?"
-    fi
-fi
 echo "getRemoteFile ended"

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -30,12 +30,10 @@ echo "  Status code: $statusCode"
 
 if echo "$statusCode" | grep -q "403"; then
     echo "Error: Forbidden"
-    rm $localFile
     exit 2
 fi
 if echo "$statusCode" | grep -q "50.*"; then
     echo "Error: Server error"
-    rm $localFile
     exit 3
 fi
 

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -32,11 +32,11 @@ echo "  Remote size: $remoteSize"
 echo "  Status code: $statusCode"
 rm "$remoteInfo"
 
-if echo "$statusCode" | grep -q "4**"; then
+if echo "$statusCode" | grep -q "4.*"; then
     echo "Error: Forbidden"
     exit 2
 fi
-if echo "$statusCode" | grep -q "5**"; then
+if echo "$statusCode" | grep -q "5.*"; then
     echo "Error: Server error"
     exit 3
 fi

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -49,7 +49,7 @@ if echo "$statusCode" | grep -q "50.*"; then
 fi
 
 if [ -f "$localFile" ]; then
-    localSize=`stat -c%s "\"$localFile\""`
+    localSize=`stat -c%s "$localFile"`
 else
     localSize=0
 fi

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -59,12 +59,13 @@ fi
 if [ "$localSize" -ge $remoteSize ]; then
     echo "File exists: skipping"
 else
-    $curlCommand -k --silent -C - -L -o "\"$localFile\"" "$linkLine" # try resuming
+    echo "Download: "$curlCommand -k --silent -C - -L -o "$localFile" "$linkLine" # try resuming
+    $curlCommand -k --silent -C - -L -o "$localFile" "$linkLine" # try resuming
     status=$?
     echo "Status: $?"
     if [ $status -ne 0 ]; then
         echo "Error resuming: redownload file ($status)"
-        $curlCommand -k --silent -L -o "\"$localFile\"" "$linkLine" # restart download
+        $curlCommand -k --silent -L -o "$localFile" "$linkLine" # restart download
         echo "Status: $?"
     fi
 fi

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -3,13 +3,14 @@
 linkLine="$1"
 localFile="$2"
 user="$3"
+extra="$4"
 remoteInfo="/tmp/.kobocloud-remote-file-info.txt"
 
 #load config
 . `dirname $0`/config.sh
 
 curlCommand="$CURL"
-if [ ! -z "$user" ]; then
+if [ ! -z "$user" ] && [ "$user" != "-" ]; then
     echo "User: $user"
     curlCommand="$curlCommand -u $user: "
 fi
@@ -17,6 +18,12 @@ fi
 if [ ! -z "$UserAgent" ]; then
     echo "Using custom userAgent: $UserAgent"
     curlCommand="$curlCommand -A '$UserAgent' "
+fi
+
+curlCommand="$curlCommand $CurlExtra "
+if [ ! -z "$extra" ]; then
+    echo "Adding extra curl arguments: $extra"
+    curlCommand="$curlCommand $extra"
 fi
 
 curlHead="$curlCommand -k -L --silent --head $linkLine"

--- a/src/usr/local/kobocloud/getpCloudFiles.sh
+++ b/src/usr/local/kobocloud/getpCloudFiles.sh
@@ -23,4 +23,8 @@ do
   #echo $outFileName
   localFile="$outDir/$outFileName"
   `dirname $0`/getRemoteFile.sh "$linkLine" "$localFile"
+  if [ $? -ne 0 ] ; then
+      echo "Having problems contacting Owncloud. Try again in a couple of minutes."
+      exit
+  fi
 done

--- a/src/usr/local/kobocloud/udev_program.sh
+++ b/src/usr/local/kobocloud/udev_program.sh
@@ -13,4 +13,4 @@ fi
 [ ! -e "$SD" ] && mkdir -p "$SD" >/dev/null 2>&1
 
 #output to log
-`dirname $0`/get.sh &> $Logs/get.log &
+`dirname $0`/get.sh > $Logs/get.log 2>&1 &


### PR DESCRIPTION
Google drive seems to be returning errors regarding automated requests. Kobocloud is not handling such scenarios appropriately.

In this PR I'm:

- Add error handling for GDrive (4xx and 5xx)
- Add a new configuration for User Agent (maybe this will fool google, or reduce detection rate)
- Enhance logging format

Example output:

```
2020-05-10_15:31:48 waiting for internet connection
Reading https://drive.google.com/drive/folders/<ID>
Getting https://drive.google.com/drive/folders/<ID>
Getting https://drive.google.com/drive/folders/<ID>
<ID>
File info: <FILEID>,x22<FILENAME>
File code: <FILEID>
File name: <FILENAME>
Using custom userAgent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36
Getting remote file information:
  Command: '/usr/local/kobocloud/curl --cacert "/usr/local/kobocloud/ca-bundle.crt"  -A 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36'  -k -L --silent --head https://drive.google.com/uc?id=<ID>&export=download'
  Status: 0
Remote file information:
  Remote size: 
  Status code: 405
Error: Forbidden
Having problems contacting Google Drive. Try again in a couple of minutes.
Reading #UNINSTALL
Comment found
2020-05-10_15:31:59 done

```