### PR TITLE
Add initial rclone support

### DIFF
--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -40,6 +40,8 @@ while read url; do
       $KC_HOME/getpCloudFiles.sh "$url" "$Lib"
     elif echo $url | grep -q '^https*://drive.google.com'; then
       $KC_HOME/getGDriveFiles.sh "$url" "$Lib"
+	elif echo $url | grep -q '^RCLONE'; then
+	  $KC_HOME/getRcloneFiles.sh "$url" "$Lib"
     else
       $KC_HOME/getOwncloudFiles.sh "$url" "$Lib"
     fi

--- a/src/usr/local/kobocloud/getRcloneFiles.sh
+++ b/src/usr/local/kobocloud/getRcloneFiles.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+baseURL="$1"
+outDir="$2"
+
+#load config
+. $(dirname $0)/config.sh
+
+rclone_config="/mnt/onboard/.add/kobocloud/kobo_rclone.conf"
+RCLONE="$KC_HOME/rclone"
+
+# Strip "RCLONE " from baseURL to get rclone path
+baseURL=`echo ${baseURL} | sed 's/^[^ ]* //'`
+
+# Rclone sync from baseURL (now RCLONE path) to outDir
+${RCLONE} sync --config ${rclone_config} --no-check-certificate ${baseURL} ${outDir}


### PR DESCRIPTION
Here's a first swag at adding `rclone` support.

Good:
- Kinda sorta works!
- I think it supports subdirectories even (didn't fully test this, but seemed to in my quick test)

Bad:
- Includes an `rclone` binary (should really wget it from the static URL on the rclone site)
- Hard-codes the path to the rclone config file as `kobo_rclone.conf` in the `kobocloud` directory
- Abuses the `kobocloudrc` syntax since you cannot really identify an rclone path via URL

To make this work, you need to do a couple things:

1. Install `rclone` somewhere, and create a new config for it (e.g., "ScottE_DropBox:eBooks")
2. Copy the `.rclone.conf` to the kobo, and put it in `.add/kobocloud/kobo_rclone.conf`
3. Add a line to `kobocloudrc` that looks like `RCLONE Foo` (e.g., `RCLONE ScottE_DropBox:eBooks`)

Depending on how many books you have, the first sync can take a LONG time.  Afterwards, `rclone` is pretty good about only transferring new files, so it goes quickly.

Full disclosure, I didn't yet 'make' a new `KoboRoot.tgz` with this, I was just updating files in the existing tarball for my tests.
