### PR TITLE
fixes #62

### DIFF
--- a/updateCABundle.sh
+++ b/updateCABundle.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-curl -o -L src/usr/local/kobocloud/ca-bundle.crt https://curl.haxx.se/ca/cacert.pem
+curl -L -o src/usr/local/kobocloud/ca-bundle.crt https://curl.haxx.se/ca/cacert.pem
 

--- a/updateCABundle.sh
+++ b/updateCABundle.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-curl -o src/usr/local/kobocloud/ca-bundle.crt https://curl.haxx.se/ca/cacert.pem
+curl -o -L src/usr/local/kobocloud/ca-bundle.crt https://curl.haxx.se/ca/cacert.pem
 


### PR DESCRIPTION
Adds `-L` as per #62 so that redirects are followed and the ca certs are downloaded properly.