### PR TITLE
Fix OwnCloud

### DIFF
--- a/src/usr/local/kobocloud/getOwncloudFiles.sh
+++ b/src/usr/local/kobocloud/getOwncloudFiles.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+#function to percent-decode the filename from the OwnCloud URL
+percentDecodeFileName() { printf "%b\n" "$(sed 's/+/ /g; s/%\([0-9a-f][0-9a-f]\)/\\x\1/g;')"; }
 
 baseURL="$1"
 outDir="$2"
@@ -20,7 +22,7 @@ $KC_HOME/getOwncloudList.sh $shareID $davServer |
 while read relativeLink
 do
   # process line 
-  outFileName=`basename $relativeLink | sed 's@+@ @g;s@%@\\x@g' | xargs -0 printf "%b"`
+  outFileName=`basename $relativeLink | percentDecodeFileName`
   linkLine=$davServer/$relativeLink
   localFile="$outDir/$outFileName"
   # get remote file

--- a/src/usr/local/kobocloud/getOwncloudFiles.sh
+++ b/src/usr/local/kobocloud/getOwncloudFiles.sh
@@ -21,7 +21,7 @@ while read relativeLink
 do
   # process line 
   outFileName=`basename $relativeLink`
-  linkLine=$davServer/$relativeLink
+  linkLine=$davServer$relativeLink
   localFile="$outDir/$outFileName"
   # get remote file
   $KC_HOME/getRemoteFile.sh "$linkLine" "$localFile" $shareID

--- a/src/usr/local/kobocloud/getOwncloudFiles.sh
+++ b/src/usr/local/kobocloud/getOwncloudFiles.sh
@@ -21,7 +21,7 @@ while read relativeLink
 do
   # process line 
   outFileName=`basename $relativeLink`
-  linkLine=$davServer$relativeLink
+  linkLine=$davServer/$relativeLink
   localFile="$outDir/$outFileName"
   # get remote file
   $KC_HOME/getRemoteFile.sh "$linkLine" "$localFile" $shareID

--- a/src/usr/local/kobocloud/getOwncloudFiles.sh
+++ b/src/usr/local/kobocloud/getOwncloudFiles.sh
@@ -20,7 +20,7 @@ $KC_HOME/getOwncloudList.sh $shareID $davServer |
 while read relativeLink
 do
   # process line 
-  outFileName=`basename $relativeLink`
+  outFileName=`basename $relativeLink | sed 's@+@ @g;s@%@\\x@g' | xargs -0 printf "%b"`
   linkLine=$davServer/$relativeLink
   localFile="$outDir/$outFileName"
   # get remote file

--- a/src/usr/local/kobocloud/getOwncloudList.sh
+++ b/src/usr/local/kobocloud/getOwncloudList.sh
@@ -12,5 +12,5 @@ echo '<?xml version="1.0"?>
 </a:propfind>' |
 $CURL -k --silent -i -X PROPFIND -u $user: $davServer/public.php/webdav --upload-file - -H "Depth: 1" | # get the listing
 grep -Eo '<d:href>[^<]*[^/]</d:href>' | # get the links without the folders
-sed 's@</*d:href>@@g' # remove the hrefs
+sed 's@</*d:href>@@g' | # remove the hrefs
 sed 's/\/public/public/'

--- a/src/usr/local/kobocloud/getOwncloudList.sh
+++ b/src/usr/local/kobocloud/getOwncloudList.sh
@@ -12,4 +12,5 @@ echo '<?xml version="1.0"?>
 </a:propfind>' |
 $CURL -k --silent -i -X PROPFIND -u $user: $davServer/public.php/webdav --upload-file - -H "Depth: 1" | # get the listing
 grep -Eo '<d:href>[^<]*[^/]</d:href>' | # get the links without the folders
-sed 's@</*d:href>/@@g' # remove the hrefs
+sed 's@</*d:href>@@g' # remove the hrefs
+sed 's/\/public/public/'


### PR DESCRIPTION
OwnCloud sync did not work for me. In OwnCloud, the result was that there was a leading '/' before the link (eg. "/public/webdav/FILENAME"). In getOwncloudFiles.sh, another / is added at the start of the link. The resulting link will be like this: SERVER//public.php/webdav/FILENAME. This results in an error. To prevent this, the leading '/' needs to be removed (if it exists).

Also solve issue where the filenames saved with a percent-encoded filename. Percent-decode filename before saving.
