### PR TITLE
Fix not reading the last line of kobocloudrc

### DIFF
--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -31,7 +31,7 @@ then
     done
 fi
 
-while read url; do
+while read url || [ -n "$url" ]; do
   echo "Reading $url"
   if echo "$url" | grep -q '^#'; then
     echo "Comment found"

--- a/src/usr/local/kobocloud/kobocloudrc.tmpl
+++ b/src/usr/local/kobocloud/kobocloudrc.tmpl
@@ -1,5 +1,3 @@
 # Add your URLs to this file
 # Remove the # from the following line to uninstall KoboCloud
 #UNINSTALL
-
-# Add your URLs above this line. Keep this as the last line in the file.


### PR DESCRIPTION
If the url of a cloud service was in the last segment of the config file (last 'line', without a newline), it was skipped. You needed to add a newline to make it work. That's not needed anymore with this change.