### PR TITLE
Stop using grep -P in the Box integration

### DIFF
--- a/src/usr/local/kobocloud/getBoxFiles.sh
+++ b/src/usr/local/kobocloud/getBoxFiles.sh
@@ -14,12 +14,12 @@ echo "Getting $baseURL"
 boxDirCode=`echo $baseURL | sed 's@.*/\(.*\)$@\1@'`
 
 pageContent=`$CURL -k -L --silent "$baseURL"`
-numPages=`echo $pageContent | grep -Po 'pageCount":[0-9]+,' | sed -n 's/pageCount":\([0-9]*\),/\1/p'`
+numPages=`echo $pageContent | grep -Eo 'pageCount":[0-9]+,' | sed -n 's/pageCount":\([0-9]*\),/\1/p'`
 
 while [ "$currPage" -le "$numPages" ]
 do
     echo "$pageContent" | 
-    grep -Po 'typedID":"[^"]+","type":"file","id":[0-9]+,(.+?),"name":"[^"]+"' | # find links
+    grep -Eo 'typedID":"[^"]+","type":"file","id":[0-9]+,(.+?),"name":"[^"]+"' | # find links
     while read fileInfo
     do
         #echo "File info: $fileInfo"

--- a/src/usr/local/kobocloud/getBoxFiles.sh
+++ b/src/usr/local/kobocloud/getBoxFiles.sh
@@ -19,7 +19,7 @@ numPages=`echo $pageContent | grep -Eo 'pageCount":[0-9]+,' | sed -n 's/pageCoun
 while [ "$currPage" -le "$numPages" ]
 do
     echo "$pageContent" | 
-    grep -Eo 'typedID":"[^"]+","type":"file","id":[0-9]+,(.+?),"name":"[^"]+"' | # find links
+    grep -Eo 'typedID":"[^"]+","type":"file","id":[0-9]+,(.*),"name":"[^"]+","itemSize"' | # find links
     while read fileInfo
     do
         #echo "File info: $fileInfo"


### PR DESCRIPTION
Grep -P is not supported on Kobo. At least not on my Kobo. Thus, it should be avoided.