### PR TITLE
Fix Box support (grep Perl regex not available in Kobo)

### DIFF
--- a/src/usr/local/kobocloud/getBoxFiles.sh
+++ b/src/usr/local/kobocloud/getBoxFiles.sh
@@ -14,12 +14,12 @@ echo "Getting $baseURL"
 boxDirCode=`echo $baseURL | sed 's@.*/\(.*\)$@\1@'`
 
 pageContent=`$CURL -k -L --silent "$baseURL"`
-numPages=`echo $pageContent | grep -Po 'pageCount":[0-9]+,' | sed -n 's/pageCount":\([0-9]*\),/\1/p'`
+numPages=`echo $pageContent | grep -Eo 'pageCount":[0-9]+,' | sed -n 's/pageCount":\([0-9]*\),/\1/p'`
 
 while [ "$currPage" -le "$numPages" ]
 do
     echo "$pageContent" | 
-    grep -Po 'typedID":"[^"]+","type":"file","id":[0-9]+,(.+?),"name":"[^"]+"' | # find links
+    grep -Eo 'typedID":"[^"]+","type":"file","id":[0-9]+,[^,]+,[^,]+,[^,]+,[^,]+,[^,]+,[^,]+,"name":"[^"]+"' | # find links
     while read fileInfo
     do
         #echo "File info: $fileInfo"


### PR DESCRIPTION
_(tl;dr Fixing my own mistakes.)_

I initially contributed Box.com support, but failed to test it properly on my Kobo device. The tests passed, but `grep -P` is not supported in Kobo devices, as @VPeeters noticed and tried to fix in PR #75 (later reverted in PR #76 probably because then the tests started failing).

I'm now contributing a fix for this issue. The script for Box.com now uses `grep -E` as other scripts do, but had to use a different regular expression. The new regex seems more prone to breaking, but at least it doesn't require Perl's regex lazy matching ability. 

Tested on a Kobo Libra H2O. Please let me know if there are any remaining issues, because I only have access to one Kobo device for testing.