### PR TITLE
Match files on remote server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Configuration example:
 https://drive.google.com/drive/folders/<ID>?usp=sharing
 # Dropbox:
 https://www.dropbox.com/sh/pgSHORTENED
+MATCH_REMOTE
 ```
 
 Some important advice:
@@ -89,6 +90,15 @@ Files added into a subfolder of the *public* folder of pCloud are also supported
 
 Please note that, even though the script supports folders where the file list has multiple pages, having a list with many pages might not work.
 
+### Matching remote server
+To delete files from library when they are no longer in the remote server:
+
+- Edit the kobocloudrc file so it contains the phrase `MATCH_REMOTE` in a single line (all capital, no spaces before or after).
+- Restart your Kobo.
+
+The next time the Kobo is connected to the internet, it will delete any files (it will not delete directories) that are not in the remote server.
+
+
 ## Usage
 
 The new files will be downloaded when the kobo connects to the Internet for a sync. Sometimes few minutes is needed after the sync process for the device to recognize and import new downloaded content.
@@ -103,14 +113,6 @@ To properly uninstall KoboCloud:
 The next time the Kobo is connected to the Internet, the program will delete itself.
 
 Note: The directory .add/kobocloud will not be deleted: after connecting the device to a computer, you should move the files from the Library subfolder in order not to lose your content, and delete the whole kobocloud directory manually.
-
-## Matching remote server
-To delete files from library when they are no longer in the remote server:
-
-- Edit the kobocloudrc file so it contains the phrase `MATCH_REMOTE` in a single line (all capital, no spaces before or after)
-- Restart your Kobo
-
-The next time the Kobo is connected to the internet, it will delete any files (it will not delete directories) that are not in the remote server.
 
 ## Installation from source code
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Configuration example:
 https://drive.google.com/drive/folders/<ID>?usp=sharing
 # Dropbox:
 https://www.dropbox.com/sh/pgSHORTENED
-MATCH_REMOTE
+REMOVE_DELETED
 ```
 
 Some important advice:
@@ -93,7 +93,7 @@ Please note that, even though the script supports folders where the file list ha
 ### Matching remote server
 To delete files from library when they are no longer in the remote server:
 
-- Edit the kobocloudrc file so it contains the phrase `MATCH_REMOTE` in a single line (all capital, no spaces before or after).
+- Edit the kobocloudrc file so it contains the phrase `REMOVE_DELETED` in a single line (all capital, no spaces before or after).
 - Restart your Kobo.
 
 The next time the Kobo is connected to the internet, it will delete any files (it will not delete directories) that are not in the remote server.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,14 @@ The next time the Kobo is connected to the Internet, the program will delete its
 
 Note: The directory .add/kobocloud will not be deleted: after connecting the device to a computer, you should move the files from the Library subfolder in order not to lose your content, and delete the whole kobocloud directory manually.
 
+## Matching remote server
+To delete files from library when they are no longer in the remote server:
+
+- Edit the kobocloudrc file so it contains the phrase `MATCH_REMOTE` in a single line (all capital, no spaces before or after)
+- Restart your Kobo
+
+The next time the Kobo is connected to the internet, it will delete any files (it will not delete directories) that are not in the remote server.
+
 ## Installation from source code
 
 To install KoboCloud from source code:

--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -31,6 +31,8 @@ then
     done
 fi
 
+echo "$Lib/filesList.log" > "$Lib/filesList.log"
+
 while read url || [ -n "$url" ]; do
   echo "Reading $url"
   if echo "$url" | grep -q '^#'; then
@@ -52,6 +54,21 @@ while read url || [ -n "$url" ]; do
     fi
   fi
 done < $UserConfig
+
+recursiveUpdateFiles() {
+for item in *; do
+	if [ -d "$item" ]; then 
+		(cd -- "$item" && recursiveUpdateFiles)
+	elif grep -q $item "$Lib/filesList.log"; then
+		echo "$item found"
+	else
+		echo "$item not found, deleting"
+		rm "$item"
+	fi
+done
+}
+cd "$Lib"
+recursiveUpdateFiles
 
 if [ "$TEST" = "" ]
 then

--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -13,7 +13,7 @@ if grep -q '^UNINSTALL$' $UserConfig; then
     exit 0
 fi
 
-if grep -q "^MATCH_REMOTE$" $UserConfig; then
+if grep -q "^REMOVE_DELETED$" $UserConfig; then
 	echo "$Lib/filesList.log" > "$Lib/filesList.log"
 fi
 
@@ -40,7 +40,7 @@ while read url || [ -n "$url" ]; do
   echo "Reading $url"
   if echo "$url" | grep -q '^#'; then
     echo "Comment found"
-  elif echo "$url" | grep -q "^MATCH_REMOTE$"; then
+  elif echo "$url" | grep -q "^REMOVE_DELETED$"; then
 	echo "Will match remote"
   else
     echo "Getting $url"
@@ -73,7 +73,7 @@ for item in *; do
 done
 }
 
-if grep -q "^MATCH_REMOTE$" $UserConfig; then
+if grep -q "^REMOVE_DELETED$" $UserConfig; then
 	cd "$Lib"
 	echo "Matching remote server"
 	recursiveUpdateFiles

--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -13,6 +13,11 @@ if grep -q '^UNINSTALL$' $UserConfig; then
     exit 0
 fi
 
+if grep -q "^MATCH_REMOTE$" $UserConfig; then
+	echo "$Lib/filesList.log" > "$Lib/filesList.log"
+fi
+
+
 if [ "$TEST" = "" ]
 then
     #check internet connection
@@ -31,12 +36,12 @@ then
     done
 fi
 
-echo "$Lib/filesList.log" > "$Lib/filesList.log"
-
 while read url || [ -n "$url" ]; do
   echo "Reading $url"
   if echo "$url" | grep -q '^#'; then
     echo "Comment found"
+  elif echo "$url" | grep -q "^MATCH_REMOTE$"; then
+	echo "Will match remote"
   else
     echo "Getting $url"
     if echo $url | grep -q '^https*://www.dropbox.com'; then # dropbox link?
@@ -67,8 +72,12 @@ for item in *; do
 	fi
 done
 }
-cd "$Lib"
-recursiveUpdateFiles
+
+if grep -q "^MATCH_REMOTE$" $UserConfig; then
+	cd "$Lib"
+	echo "Matching remote server"
+	recursiveUpdateFiles
+fi
 
 if [ "$TEST" = "" ]
 then

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -43,7 +43,9 @@ if echo "$statusCode" | grep -q "50.*"; then
     exit 3
 fi
 
-echo "$localFile" >> "$Lib/filesList.log"
-echo "Appended $localFile to filesList"
+if grep -q "^MATCH_REMOTE" $UserConfig; then
+	echo "$localFile" >> "$Lib/filesList.log"
+	echo "Appended $localFile to filesList"
+fi
 echo "getRemoteFile ended"
 

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -43,4 +43,7 @@ if echo "$statusCode" | grep -q "50.*"; then
     exit 3
 fi
 
+echo "$localFile" >> "$Lib/filesList.log"
+echo "Appended $localFile to filesList"
 echo "getRemoteFile ended"
+

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -43,7 +43,7 @@ if echo "$statusCode" | grep -q "50.*"; then
     exit 3
 fi
 
-if grep -q "^MATCH_REMOTE" $UserConfig; then
+if grep -q "^REMOVE_DELETED" $UserConfig; then
 	echo "$localFile" >> "$Lib/filesList.log"
 	echo "Appended $localFile to filesList"
 fi

--- a/src/usr/local/kobocloud/kobocloudrc.tmpl
+++ b/src/usr/local/kobocloud/kobocloudrc.tmpl
@@ -2,4 +2,4 @@
 # Remove the # from the following line to uninstall KoboCloud
 #UNINSTALL
 # Remove the # from the following line to delete files when they are no longer on the remote server
-#MATCH_REMOTE
+#REMOVE_DELETED

--- a/src/usr/local/kobocloud/kobocloudrc.tmpl
+++ b/src/usr/local/kobocloud/kobocloudrc.tmpl
@@ -1,3 +1,5 @@
 # Add your URLs to this file
 # Remove the # from the following line to uninstall KoboCloud
 #UNINSTALL
+# Remove the # from the following line to delete files when they are no longer on the remote server
+#MATCH_REMOTE


### PR DESCRIPTION
Added some rudimentary code (first pull request I've done) to delete files from Kobo which are not on the remote server, which can be toggled by adding `MATCH_REMOTE` to the kobocloudrc file. Recursion is used to remove nested files. However, it will not delete directories. 