### PR TITLE
Implement sync with a Dropbox App

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A set of scripts to synchronize a kobo reader with popular cloud services.
 
 The following cloud services are supported:
 
-- Dropbox
+- Dropbox (two methods)
 - Google Drive
 - NextCloud/OwnCloud
 - pCloud
@@ -47,13 +47,23 @@ Some important advice:
 - **no subdirectories** are supported at the moment, your books must be all in the same directories that you are sharing
 - **restart your Kobo** after any kobocloudrc changes to to make them effective
 
-### Dropbox
+### Dropbox public folder (limited)
 
-To add a Dropbox link:
+To add a Dropbox public link:
 
 - Open your dropbox in a browser
 - Select the folder that you want to share and click "Share" and "Send link"
 - Copy the link that appears into the kobocloudrc file
+
+Note: this method does not work for folders with more than ~30 books, see https://github.com/fsantini/KoboCloud/issues/123.
+
+### Dropbox private folder
+
+This method will create a folder `/Applications/Kobo Cloud Sync` in your Dropbox and sync with it.
+
+- Open this [link](https://www.dropbox.com/oauth2/authorize?client_id=5oyw72cfwcp352f&response_type=token&redirect_uri=https://louisabraham.github.io/KoboCloud)
+- Copy the line starting with `DropboxApp:`
+- Add it to your `kobocloudrc` file
 
 ### Google Drive
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,17 +12,33 @@
   <div class="container-lg px-3 my-5 markdown-body">
 
     <h1>Kobo Cloud Sync</h1>
-    <p>Add the following line in the kobocloudrc file:</p>
+    <p>Add the following line in the kobocloudrc file (click to copy):</p>
 
-    <pre id="token"></pre>
+    <pre id="token" onclick="copy()"></pre>
   </div>
 </body>
 
 </html>
 
+<style>
+  div {
+    margin: auto;
+    max-width: fit-content;
+  }
+</style>
 <script>
   let token = new URLSearchParams(
     window.location.hash.substr(1) // skip the first char (#)
   ).get('access_token')
-  document.getElementById("token").innerHTML = "DropboxApp:" + token;
+  let pre = document.getElementById("token")
+  pre.innerText = "DropboxApp:" + token;
+  let copy = () => {
+    navigator.clipboard.writeText(pre.innerText);
+    let alert = document.createElement("p");
+    alert.innerHTML = "Copied!"
+    pre.parentNode.insertBefore(alert, pre.nextSibling);
+    setTimeout(() => {
+      alert.parentNode.removeChild(alert);
+    }, 1000);
+  }
 </script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en-US">
+
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Kobo Cloud Sync | KoboCloud</title>
+</head>
+
+<body>
+  <div class="container-lg px-3 my-5 markdown-body">
+
+    <h1>Kobo Cloud Sync</h1>
+    <p>Add the following line in the kobocloudrc file:</p>
+
+    <pre id="token"></pre>
+  </div>
+</body>
+
+</html>
+
+<script>
+  let token = new URLSearchParams(
+    window.location.hash.substr(1) // skip the first char (#)
+  ).get('access_token')
+  document.getElementById("token").innerHTML = "DropboxApp:" + token;
+</script>

--- a/src/usr/local/kobocloud/config.sh
+++ b/src/usr/local/kobocloud/config.sh
@@ -3,7 +3,7 @@
 KC_HOME=$(dirname $0)
 ConfigFile=$KC_HOME/kobocloudrc.tmpl
 
-if uname -a | grep -q x86
+if uname -a | grep -q 'x86\|Darwin'
 then
     #echo "PC detected"
     . $KC_HOME/config_pc.sh

--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -46,6 +46,9 @@ while read url || [ -n "$url" ]; do
     echo "Getting $url"
     if echo $url | grep -q '^https*://www.dropbox.com'; then # dropbox link?
       $KC_HOME/getDropboxFiles.sh "$url" "$Lib"
+    elif echo $url | grep -q '^DropboxApp:'; then # dropbox token
+      token=`echo $url | sed -e 's/^DropboxApp://' -e 's/[[:space:]]*$//'`
+      $KC_HOME/getDropboxAppFiles.sh "$token" "$Lib"
     elif echo $url | grep -q '^https*://filedn.com'; then
       $KC_HOME/getpCloudFiles.sh "$url" "$Lib"
     elif echo $url | grep -q '^https*://[^/]*pcloud'; then

--- a/src/usr/local/kobocloud/getDropboxAppFiles.sh
+++ b/src/usr/local/kobocloud/getDropboxAppFiles.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+token="$1"
+outDir="$2"
+
+#load config
+. $(dirname $0)/config.sh
+
+# get directory listing
+$CURL -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.89 Safari/537.36" -k -L --silent "$baseURL" | # get listing. Need to specify a user agent, otherwise it will download the directory
+grep -Eo 'ShmodelFolderEntriesPrefetch.*' | 
+grep -Eo 'https?://www.dropbox.com/sh/[^\"]*' | # find links
+sort -u | # remove duplicates
+
+$CURL -k --silent -X POST https://api.dropboxapi.com/2/files/list_folder \
+    --header "Authorization: Bearer $token" \
+    --header "Content-Type: application/json" \
+    --data '{"path": "","include_non_downloadable_files": false}' |
+sed -e 's/^.*\[{//' -e 's/}\].*$//' -e 's/}, {/\n/g' |
+grep '".tag": "file"' | grep '"is_downloadable": true' |
+while read item
+do
+  outFileName=`echo $item | sed 's/.*"name": "\([^"]*\)", ".*/\1/'`
+  remotePath=`echo $item | sed 's/.*"path_lower": "\([^"]*\)", ".*/\1/'`
+  localFile="$outDir/$outFileName"
+  $KC_HOME/getRemoteFile.sh "https://content.dropboxapi.com/2/files/download" "$localFile" "$token" "$remotePath"
+  if [ $? -ne 0 ] ; then
+      echo "Having problems contacting Dropbox. Try again in a couple of minutes."
+      exit
+  fi
+done

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -28,9 +28,9 @@ if [ ! -z "$user" ] && [ "$user" != "-" ]; then
     curlCommand="$curlCommand -u $user: "
 fi
 
-echo "Download: "$curlCommand -k --silent -C - -L --create-dirs -o "$localFile" "$linkLine" -v
+echo "Download:" $curlCommand -k --silent -C - -L --create-dirs -o \"$localFile\" \"$linkLine\" -v
 
-$curlCommand -k --silent -C - -L --create-dirs -o "$localFile" "$linkLine" -v 2>$outputFileTmp
+eval $curlCommand -k --silent -C - -L --create-dirs -o \"$localFile\" \"$linkLine\" -v 2>$outputFileTmp
 status=$?
 echo "Status: $status"
 echo "Output: "
@@ -53,7 +53,7 @@ if echo "$statusCode" | grep -q "50.*"; then
     if [ $errorResume ] && [ "$retry" = "TRUE" ]
     then
         echo "Can't resume. Checking size"
-        contentLength=`$curlCommand -k -sLI "$linkLine" | grep -i 'Content-Length' | sed 's/.*:\s*\([0-9]*\).*/\1/'`
+        contentLength=$(eval $curlCommand -k -sLI "$linkLine" | grep -i 'Content-Length' | sed 's/.*:\s*\([0-9]*\).*/\1/')
         existingLength=`stat --printf="%s" "$localFile"`
         echo "Remote length: $contentLength"
         echo "Local length: $existingLength"

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -11,6 +11,7 @@ fi
 linkLine="$1"
 localFile="$2"
 user="$3"
+dropboxPath="$4"
 outputFileTmp="/tmp/kobo-remote-file-tmp.log"
 
 # add the epub extension to kepub files
@@ -26,6 +27,10 @@ curlCommand="$CURL"
 if [ ! -z "$user" ] && [ "$user" != "-" ]; then
     echo "User: $user"
     curlCommand="$curlCommand -u $user: "
+fi
+
+if [ ! -z "$dropboxPath" ] && [ "$dropboxPath" != "-" ]; then
+    curlCommand="$CURL -X POST --header \"Authorization: Bearer $user\" --header \"Dropbox-API-Arg: {\\\"path\\\": \\\"$dropboxPath\\\"}\""
 fi
 
 echo "Download:" $curlCommand -k --silent -C - -L --create-dirs -o \"$localFile\" \"$linkLine\" -v


### PR DESCRIPTION
To solve the issues I got in #123, I created a Dropbox App that syncs an app folder using the official API.

The user gets the authorization token by clicking on the following link that is included in the README: https://www.dropbox.com/oauth2/authorize?client_id=5oyw72cfwcp352f&response_type=token&redirect_uri=https://louisabraham.github.io/KoboCloud

The workflow redirects to a static page (https://louisabraham.github.io/KoboCloud) displaying the token for the user and this page is contained in `/docs`.

This authorization token is limited to reading the files in the app folder.

If more than 500 people use that app, it will need to be approved by Dropbox as an official Dropbox app. Even if they were to refuse, it would be easy to recreate the same, and simply change the `client_id` in the authorization link.

Steps to create such an app:
- go to https://www.dropbox.com/developers/apps
- create an app, they are calling it "Scoped App (App Folder)" right now
- give permission `files.content.read`
- select "No expiration" for "Access token expiration"
- allow the URL of the static page (https://louisabraham.github.io/KoboCloud) as a redirect URL
- replace `5oyw72cfwcp352f` with the "App key" in the link above

I tested and it works flawlessly for me. I cannot provide testcases since it does not support public links.