### PR TITLE
Fix some bugs with special filenames

### DIFF
--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -67,7 +67,7 @@ recursiveUpdateFiles() {
 for item in *; do
 	if [ -d "$item" ]; then 
 		(cd -- "$item" && recursiveUpdateFiles)
-	elif grep -q "$item" "$Lib/filesList.log"; then
+	elif grep -Fq "$item" "$Lib/filesList.log"; then
 		echo "$item found"
 	else
 		echo "$item not found, deleting"

--- a/src/usr/local/kobocloud/getDropboxAppFiles.sh
+++ b/src/usr/local/kobocloud/getDropboxAppFiles.sh
@@ -12,10 +12,11 @@ grep -Eo 'ShmodelFolderEntriesPrefetch.*' |
 grep -Eo 'https?://www.dropbox.com/sh/[^\"]*' | # find links
 sort -u | # remove duplicates
 
-$CURL -k --silent -X POST https://api.dropboxapi.com/2/files/list_folder \
+response=$($CURL -k --silent -X POST https://api.dropboxapi.com/2/files/list_folder \
     --header "Authorization: Bearer $token" \
     --header "Content-Type: application/json" \
-    --data '{"path": "","include_non_downloadable_files": false}' |
+    --data '{"path": "","include_non_downloadable_files": false}')
+echo "$response" |
 sed -e 's/^.*\[{//' -e 's/}\].*$//' -e 's/}, {/\n/g' |
 grep '".tag": "file"' | grep '"is_downloadable": true' |
 while read item

--- a/src/usr/local/kobocloud/getDropboxAppFiles.sh
+++ b/src/usr/local/kobocloud/getDropboxAppFiles.sh
@@ -7,11 +7,6 @@ outDir="$2"
 . $(dirname $0)/config.sh
 
 # get directory listing
-$CURL -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.89 Safari/537.36" -k -L --silent "$baseURL" | # get listing. Need to specify a user agent, otherwise it will download the directory
-grep -Eo 'ShmodelFolderEntriesPrefetch.*' | 
-grep -Eo 'https?://www.dropbox.com/sh/[^\"]*' | # find links
-sort -u | # remove duplicates
-
 response=$($CURL -k --silent -X POST https://api.dropboxapi.com/2/files/list_folder \
     --header "Authorization: Bearer $token" \
     --header "Content-Type: application/json" \


### PR DESCRIPTION
I fix two bugs:
1. one general affecting filenames containing brackets affecting `get.sh`, thus all methods. This bug was not correctly detecting if files were on the cloud and was deleting then when `REMOVE_DELETED` was activated.
2. one affecting `getDropboxAppFiles.sh`, as the Dropbox API suddently started to return escaped unicode characters