### PR TITLE
Support the new sharing format/urls of pCloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Subdirectories are supported for NextCloud (OwnCloud).
 
 - Add the public link to the containing folder to the kobocloudrc file.
 
-Files added into a subfolder of the *public* folder of pCloud are also supported.
+~~Files added into a subfolder of the *public* folder of pCloud are also supported.~~
+Due to a different download method for pCloud (new share links have a different format) subfolders are only supported on the older share folders. Not on the newer ones.
 
 ### Box
 

--- a/local_test.sh
+++ b/local_test.sh
@@ -13,6 +13,7 @@ then
 elif [ "$SERVICE" = "pcloud" ]
 then
     URL='https://u.pcloud.link/publink/show?code=kZBWSsXZPYXgN8YJtmjGSKNCQERxG80M2WiX'
+    #URL='https://filedn.eu/lIJBHCuls5a4Nhjv5GJErfV'
 elif [ "$SERVICE" = "box" ]
 then
     URL='https://app.box.com/s/1y5e82xbyksuywamih7vu08yaiefqm65'

--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -51,9 +51,7 @@ while read url || [ -n "$url" ]; do
       client_id=`echo $auth | sed 's/:.*//'`
       refresh_token=`echo $auth | sed 's/.*://'`
       $KC_HOME/getDropboxAppFiles.sh "$client_id" "$refresh_token" "$Lib"
-    elif echo $url | grep -q '^https*://filedn.com'; then
-      $KC_HOME/getpCloudFiles.sh "$url" "$Lib"
-    elif echo $url | grep -q '^https*://[^/]*pcloud'; then
+    elif echo $url | grep -q '^https*://filedn.com\|^https*://filedn.eu\|^https*://[^/]*pcloud'; then
       $KC_HOME/getpCloudFiles.sh "$url" "$Lib"
     elif echo $url | grep -q '^https*://drive.google.com'; then
       $KC_HOME/getGDriveFiles.sh "$url" "$Lib"

--- a/src/usr/local/kobocloud/getDropboxAppFiles.sh
+++ b/src/usr/local/kobocloud/getDropboxAppFiles.sh
@@ -6,7 +6,6 @@ outDir="$3"
 
 #load config
 . $(dirname $0)/config.sh
-
 token=`$CURL -k --silent https://api.dropbox.com/oauth2/token \
     -d grant_type=refresh_token \
     -d client_id=$client_id \

--- a/src/usr/local/kobocloud/getpCloudFiles.sh
+++ b/src/usr/local/kobocloud/getpCloudFiles.sh
@@ -2,32 +2,32 @@
 
 baseURL="$1"
 outDir="$2"
-
+foundOldWay=false
 #load config
 . $(dirname $0)/config.sh
 
 code=`echo $baseURL | sed 's/.*code=\([a-zA-Z0-9]*\).*/\1/'`
 
-echo $code
-
 # get directory listing
-echo "Getting $baseURL"
+#echo "Getting $baseURL"
+echo "Using pCloud scraping, do not use subfolders, these might not be downloaded."
 # get directory listing
 $CURL -k -L --silent "$baseURL" |
 grep -Eo '"fileid": [0-9]+' |
 sed 's/"fileid": \([0-9]*\)/\1/' | # find links
 while read fileid
 do
-  echo $fileid
+  foundOldWay=true
+  echo "FileID: "$fileid
   
   # get public ID
   jsonAns=`$CURL -k -L --silent "https://api.pcloud.com/getpublinkdownload?code=$code&forcedownload=1&fileid=$fileid"`
-  echo $jsonAns
+  echo "jsonAns1: "$jsonAns
   
   if echo $jsonAns | grep -q "error" # try European API
   then
     jsonAns=`$CURL -k -L --silent "https://eapi.pcloud.com/getpublinkdownload?code=$code&forcedownload=1&fileid=$fileid"`
-    echo $jsonAns
+    echo "jsonAns2: "$jsonAns
   fi
   
   if echo $jsonAns | grep -q "error"
@@ -47,9 +47,41 @@ do
   
   # process line 
   localFile="$outDir/$outFileName"
+  # add the epub extension to kepub files
+  if echo "$localFile" | grep -Eq '\.kepub$'
+    then
+      localFile="$localFile.epub"
+  fi
   $KC_HOME/getRemoteFile.sh "$linkLine" "$localFile"
   if [ $? -ne 0 ] ; then
       echo "Having problems contacting pCloud. Try again in a couple of minutes."
       exit
   fi
 done
+
+if [ "$foundOldWay" == false ] ; then
+  echo "No files found using the old method, trying new method for pCloud."
+  baseURLWithSlash=$baseURL
+  baseURLWithSlash="${baseURLWithSlash%/}/"
+  $CURL -k -L --silent "$baseURL" |
+  ##get files with 3 or 4 characters extension
+  grep -Eo '"name": .+",$' |
+  ##Replace ,
+  sed -E 's/"name": "(.+)",$/\1/' |
+  while read name
+    do
+    if ! echo "$name" | grep -qE '.+\..{3,4}$'; then
+      echo "Does not seem like a file so skipping: "$name
+      continue
+    fi
+    echo "Processing: "$name
+    linkLine=$baseURLWithSlash$name
+    localFile="$outDir/$outFileName"
+    $KC_HOME/getRemoteFile.sh "$linkLine" "$localFile"
+    outFileName=`echo $name | sed 's@.*/\([^/]*\)@\1@'`
+    if [ $? -ne 0 ] ; then
+      echo "Having problems contacting pCloud. Try again in a couple of minutes."
+      exit
+    fi
+  done
+fi


### PR DESCRIPTION
PCloud seems to support a new sharing format for public folders.
The "basics" of that new format are now supported and the .eu link is also matched.
This version does not include handling of the subfolders yet. And it is not my intention to add this in the near feature, so unsupported yet.