### PR TITLE
Auto confirm large file downloads

### DIFF
--- a/src/usr/local/kobocloud/getGDriveFiles.sh
+++ b/src/usr/local/kobocloud/getGDriveFiles.sh
@@ -44,7 +44,7 @@ do
     fileName=`echo $fileInfo | sed -n 's/\(.*\)|.*/\1/p'` # extract the file name
     echo "File code: $fileCode"
     echo "File name: $fileName"
-    linkLine="https://drive.google.com/uc?id=$fileCode&export=download"
+    linkLine="https://drive.google.com/uc?id=$fileCode&export=download&confirm=t"
     outFileName=`/bin/echo -e "$fileName" | tr ' ' '_' `
     localFile="$outDir/$outFileName"
 


### PR DESCRIPTION
Problem: Current implementation does not allow for the downloading of large files (>=200MB)

Scenario: I uploaded a manga volume, expecting it to download on to my device. It would not work.

Fix: The change adds an auto confirm flag in the `linkLine` URL, allowing downloads of larger files to go through.

I do not have experience with other cloud providers, so I am unable to test/make fixes for those services. I do have a dropbox account, so I will also try that soon. I will add tests for this as well