### PR TITLE
Avoid useless rescan : Detect if local lib files have changed after sync

### DIFF
--- a/local_test.sh
+++ b/local_test.sh
@@ -3,6 +3,7 @@
 SERVICE=$1
 TEST_DELETED=$2
 
+
 TestFiles=("ulysses.epub" "01/ulysses.epub" "01/ulysses01.epub" "02/ulysses.epub" "02/ulysses02.epub")
 sha1=d07c5da10d4666766d1b796ba420cffca0ac440c
 TestSubdirs=false
@@ -109,6 +110,9 @@ do
         exit 1
     fi
 done
+
+#relaunch sync to test when no change has to be made
+src/usr/local/kobocloud/get.sh TEST
 
 # if we reached here, we are good
 exit 0

--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -48,6 +48,10 @@ then
   fi
 fi
 
+#list file in lib dir before sync
+lib_list_before=`ls -lnR --full-time "$Lib"`
+echo "$lib_list_before"
+
 while read url || [ -n "$url" ]; do
   echo "Reading $url"
   if echo "$url" | grep -q '^#'; then
@@ -94,10 +98,23 @@ if grep -q "^REMOVE_DELETED$" $UserConfig; then
 	recursiveUpdateFiles
 fi
 
-if [ "$TEST" = "" ]
+#list file in lib dir after sync
+lib_list_after=`ls -lnR --full-time "$Lib"`
+echo "$lib_list_after"
+
+#compare filelist before and after
+if [ "$lib_list_after" = "$lib_list_before" ]
 then
-    # Use NickelDBus for library refresh
-    /usr/bin/qndb -t 3000 -s pfmDoneProcessing -m pfmRescanBooksFull
+  echo "No Library Change. skipping rescan"
+else
+  echo "Library has changed, rescan needed"
+
+
+  if [ "$TEST" = "" ]
+  then
+      # Use NickelDBus for library refresh
+      /usr/bin/qndb -t 3000 -s pfmDoneProcessing -m pfmRescanBooksFull
+  fi
 fi
 
 rm "$Logs/index" >/dev/null 2>&1

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -33,9 +33,9 @@ if [ ! -z "$dropboxPath" ] && [ "$dropboxPath" != "-" ]; then
     curlCommand="$CURL -X POST --header \"Authorization: Bearer $user\" --header \"Dropbox-API-Arg: {\\\"path\\\": \\\"$dropboxPath\\\"}\""
 fi
 
-echo "Download:" $curlCommand -k --silent -C - -L --create-dirs -o \"$localFile\" \"$linkLine\" -v
+echo "Download:" $curlCommand -k --silent -C - -L --create-dirs --remote-time -o \"$localFile\" \"$linkLine\" -v
 
-eval $curlCommand -k --silent -C - -L --create-dirs -o \"$localFile\" \"$linkLine\" -v 2>$outputFileTmp
+eval $curlCommand -k --silent -C - -L --create-dirs --remote-time -o \"$localFile\" \"$linkLine\" -v 2>$outputFileTmp
 status=$?
 echo "Status: $status"
 echo "Output: "


### PR DESCRIPTION
Rescan trigger after each sync seems to be the origin to issue #172. The PR add a comparaison of the content of the lib directory before and after the sync. The rescan will be launch only if the content has changed. Comparaison is done with the result of a detailed LS command (so, file name, size and dates). 
To avoid the date of synced files to change after each sync, adding a --remote-time to the CURL command will allow to use the remote date of the file so if files are not changed remotely, dates on the local lib will stay the same and allow comparaison of the lib content to work as expected.
