### PR TITLE
skip dropbox file based on size

### DIFF
--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -81,6 +81,9 @@ done < $UserConfig
 
 recursiveUpdateFiles() {
 for item in *; do
+  if [ "$item" = "*" ]; then
+    continue
+  fi
 	if [ -d "$item" ]; then 
 		(cd -- "$item" && recursiveUpdateFiles)
 	elif grep -Fq "$item" "$Lib/filesList.log"; then

--- a/src/usr/local/kobocloud/getDropboxAppFiles.sh
+++ b/src/usr/local/kobocloud/getDropboxAppFiles.sh
@@ -29,6 +29,8 @@ do
   if [ -z "$existingFileSize" ]; then
     existingFileSize=0
   fi
+  remotePath=`echo $item | sed 's/.*"id": "\([^"]*\)", ".*/\1/'`
+  localFile="$outDir/$outFileName"
 
   echo "outFileName: $outFileName"
   echo "outFileSize: $outFileSize"
@@ -38,11 +40,14 @@ do
     rm "$outDir/$outFileName"
   fi
   if [ "$existingFileSize" -eq "$outFileSize" ]; then
+    echo "File $outFileName is up to date"
+    if grep -q "^REMOVE_DELETED" $UserConfig; then
+      echo "$localFile" >> "$Lib/filesList.log"
+      echo "Appended $localFile to filesList"
+    fi
     continue
   fi
-  
-  remotePath=`echo $item | sed 's/.*"id": "\([^"]*\)", ".*/\1/'`
-  localFile="$outDir/$outFileName"
+
   $KC_HOME/getRemoteFile.sh "https://content.dropboxapi.com/2/files/download" "$localFile" "$token" "$remotePath"
   if [ $? -ne 0 ] ; then
       echo "Having problems contacting Dropbox. Try again in a couple of minutes."

--- a/src/usr/local/kobocloud/getDropboxAppFiles.sh
+++ b/src/usr/local/kobocloud/getDropboxAppFiles.sh
@@ -4,7 +4,7 @@ client_id="$1"
 refresh_token="$2"
 outDir="$3"
 
-#load config
+# load config
 . $(dirname $0)/config.sh
 token=`$CURL -k --silent https://api.dropbox.com/oauth2/token \
     -d grant_type=refresh_token \
@@ -23,7 +23,24 @@ grep '".tag": "file"' | grep '"is_downloadable": true' |
 while read item
 do
   outFileName=`echo $item | sed -e 's/.*"name": "\([^"]*\)", ".*/\1/'`
-  outFileName=`echo $outFileName | sed -e 's/\\u00e0/à/' -e 's/\\u00e0/â/' -e 's/\\u00e8/è/' -e 's/\\u00e9/é/' -e 's/\\u00f8/ø/' -e 's/\\u0153/œ/'`
+  outFileName=`echo $outFileName | sed -e 's/\\u00e0/à/' -e 's/\\u00e0/â/' -e 's/\\u00e8/è/' -e 's/\\u00e9/é/' -e 's/\\u00f8/ø/' -e 's/\\u0153/œ/' -e 's/\\u2014/—/'`
+  outFileSize=`echo $item | sed -e 's/.*"size": \([0-9]*\), ".*/\1/'`
+  existingFileSize=`stat -c %s "$outDir/$outFileName" 2>/dev/null`
+  if [ -z "$existingFileSize" ]; then
+    existingFileSize=0
+  fi
+
+  echo "outFileName: $outFileName"
+  echo "outFileSize: $outFileSize"
+  echo "existingFileSize: $existingFileSize"
+
+  if [ "$existingFileSize" -gt "$outFileSize" ]; then
+    rm "$outDir/$outFileName"
+  fi
+  if [ "$existingFileSize" -eq "$outFileSize" ]; then
+    continue
+  fi
+  
   remotePath=`echo $item | sed 's/.*"id": "\([^"]*\)", ".*/\1/'`
   localFile="$outDir/$outFileName"
   $KC_HOME/getRemoteFile.sh "https://content.dropboxapi.com/2/files/download" "$localFile" "$token" "$remotePath"


### PR DESCRIPTION
if the file exists and has the same size as indicated by the API, we skip it

behavior is unchanged since curl uses the -C option to resume download

if the file exists and has a greater size than indicated (weird bug I couldn't track back), we delete it

This makes the script much faster (needs only one request on already synced folders instead of one per file) and more resilient.