### PR TITLE
Add an option to remove curl verbose in log. Logs will be smaller

### DIFF
--- a/local_test.sh
+++ b/local_test.sh
@@ -2,6 +2,7 @@
 
 SERVICE=$1
 TEST_DELETED=$2
+NO_CURL_VERBOSE=$3
 
 
 TestFiles=("ulysses.epub" "01/ulysses.epub" "01/ulysses01.epub" "02/ulysses.epub" "02/ulysses02.epub")
@@ -79,6 +80,11 @@ then
     mkdir -p "$Lib/01"
     touch "$Lib/delete_me.epub"
     touch "$Lib/01/delete_me.epub"
+fi
+if [ "$NO_CURL_VERBOSE" = true ]
+then
+    echo "No verbose for curl"
+    echo "NO_CURL_VERBOSE" >> $UserConfig
 fi
 
 src/usr/local/kobocloud/get.sh TEST

--- a/src/usr/local/kobocloud/get.sh
+++ b/src/usr/local/kobocloud/get.sh
@@ -5,7 +5,7 @@ TEST=$1
 
 #load config
 . $(dirname $0)/config.sh
-
+export UserConfig
 #check if Kobocloud contains the line "UNINSTALL"
 if grep -q '^UNINSTALL$' $UserConfig; then
     echo "Uninstalling KoboCloud!"
@@ -57,7 +57,9 @@ while read url || [ -n "$url" ]; do
   if echo "$url" | grep -q '^#'; then
     echo "Comment found"
   elif echo "$url" | grep -q "^REMOVE_DELETED$"; then
-	echo "Will match remote"
+	  echo "Will match remote"
+  elif echo "$url" | grep -q "^NO_CURL_VERBOSE$"; then
+	  echo "Will have no verbose for curl"
   else
     echo "Getting $url"
     if echo $url | grep -q '^https*://www.dropbox.com'; then # dropbox link?

--- a/src/usr/local/kobocloud/getRemoteFile.sh
+++ b/src/usr/local/kobocloud/getRemoteFile.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
 
 retry="TRUE"
+curl_verbose="TRUE"
 
 if [ "$1" = "NORETRY" ]
 then
     retry="FALSE"
     shift 1
+fi
+
+if grep -q '^NO_CURL_VERBOSE$' $UserConfig; then
+    curl_verbose="FALSE"
 fi
 
 linkLine="$1"
@@ -38,8 +43,12 @@ echo "Download:" $curlCommand -k --silent -C - -L --create-dirs --remote-time -o
 eval $curlCommand -k --silent -C - -L --create-dirs --remote-time -o \"$localFile\" \"$linkLine\" -v 2>$outputFileTmp
 status=$?
 echo "Status: $status"
-echo "Output: "
-cat $outputFileTmp
+
+if [ "$curl_verbose" = "TRUE" ]
+then
+    echo "Output: "
+    cat $outputFileTmp
+fi
 
 statusCode=`grep 'HTTP/' "$outputFileTmp" | tail -n 1 | cut -d' ' -f3`
 grep -q "Cannot resume" "$outputFileTmp"

--- a/src/usr/local/kobocloud/udev_mount.sh
+++ b/src/usr/local/kobocloud/udev_mount.sh
@@ -14,6 +14,8 @@ if [ ! -e $UserConfig ]; then
     echo "# Add your URLs to this file" > $UserConfig
     echo "# Remove the # from the following line to uninstall KoboCloud" >> $UserConfig
     echo "#UNINSTALL" >> $UserConfig
+    echo "# Remove the # from the following line to have less curl verbose in log" >> $UserConfig
+    echo "#NO_CURL_VERBOSE" >> $UserConfig
   fi
 fi
 


### PR DESCRIPTION
Add a new option in config file (NO_CURL_VERBOSE) to remove curl verbose output from the log (but maintaining the http return code) . The get.log is now more readable and smaller. Fix for https://github.com/fsantini/KoboCloud/issues/191