### PR TITLE
Workaround for https://github.com/nextcloud/server/issues/57464

### DIFF
--- a/src/usr/local/kobocloud/getNextcloudList.sh
+++ b/src/usr/local/kobocloud/getNextcloudList.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+shareID="$1"
+davServer="$2"
+
+#load config
+. $(dirname $0)/config.sh
+
+echo '<?xml version="1.0"?>
+<a:propfind xmlns:a="DAV:">
+<a:prop><a:resourcetype/></a:prop>
+</a:propfind>' |
+$CURL -k --silent -i -X PROPFIND $davServer/public.php/dav/files/$shareID --upload-file - -H "Depth: infinity" | # get the listing
+grep -Eo '<d:href>[^<]*[^/]</d:href>' | # get the links without the folders
+sed 's@</*d:href>@@g'

--- a/src/usr/local/kobocloud/getOwncloudFiles.sh
+++ b/src/usr/local/kobocloud/getOwncloudFiles.sh
@@ -27,11 +27,25 @@ echo "davServer: $davServer"
 echo "davServerWithOwncloudPath: $davServerWithOwncloudPath"
 
 # get directory listing
-$KC_HOME/getOwncloudList.sh $shareID $davServerWithOwncloudPath |
+#$KC_HOME/getOwncloudList.sh $shareID $davServerWithOwncloudPath |
+
+nextCloud=false
+fileList=$($KC_HOME/getOwncloudList.sh $shareID $davServerWithOwncloudPath)
+
+if [ -z "$fileList" ]; then
+  fileList=$($KC_HOME/getNextcloudList.sh $shareID $davServerWithOwncloudPath)
+  nextCloud=true
+fi
+
+echo "$fileList" | 
 while read relativeLink
 do
   # process line 
-  outFileName=`echo $relativeLink | sed 's/.*public.php\/webdav\///' | percentDecodeFileName`
+  if [ $nextcloud ] ; then
+    outFileName=`echo $relativeLink | sed 's/.*public.php\/dav\/files\/$shareID\///' | percentDecodeFileName`
+  else
+    outFileName=`echo $relativeLink | sed 's/.*public.php\/webdav\///' | percentDecodeFileName`
+  fi
   linkLine=$davServer$relativeLink
   localFile="$outDir/$outFileName"
   # get remote file


### PR DESCRIPTION
I found that syncing with recent versions of NextCloud had stopped working. I poked around and found a bug. 

The newer link seems to be a tidier way to connect to a public share (using a URL rather than a username to differentiate between public shares) . So I've got it doing it the original way, and if the directory listing comes up empty, go and use the new link.